### PR TITLE
Coda min voltage, current precision, formatting

### DIFF
--- a/VoltBMSV2/VoltBMSV2.ino
+++ b/VoltBMSV2/VoltBMSV2.ino
@@ -3577,6 +3577,8 @@ void CanSerial() //communication with Victron system over CAN
     }
       if (settings.chargertype == Coda)
   {
+    // Data is big endian (MSB, LSB)
+    // Voltage scaling is value * 10
     msg.id  = 0x050;
     msg.len = 8;
     msg.buf[0] = 0x00;
@@ -3588,14 +3590,15 @@ void CanSerial() //communication with Victron system over CAN
     }
     else
     {
-      msg.buf[2] = highByte( 400);
-      msg.buf[3] = lowByte( 400);
+      // Voltage minimum is 200V -> 200 * 10 = 2000 -> 0x7D0
+      msg.buf[2] = 0x07;
+      msg.buf[3] = 0xD0;
     }
     msg.buf[4] = 0x00;
     if ((settings.ChargeVsetpoint * settings.Scells)*chargecurrent < 3300)
     {
       msg.buf[5] = highByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
-      msg.buf[6] = highByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
+      msg.buf[6] = lowByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
     }
     else //15 A AC limit
     {

--- a/VoltBMSV2/VoltBMSV2.ino
+++ b/VoltBMSV2/VoltBMSV2.ino
@@ -3575,40 +3575,40 @@ void CanSerial() //communication with Victron system over CAN
         can.send(0x304, 0, 0, 4, dta);
       }
     }
-      if (settings.chargertype == Coda)
-  {
-    // Data is big endian (MSB, LSB)
-    // Voltage scaling is value * 10
-    msg.id  = 0x050;
-    msg.len = 8;
-    msg.buf[0] = 0x00;
-    msg.buf[1] = 0xDC;
-    if ((settings.ChargeVsetpoint * settings.Scells ) > 200)
+
+    if (settings.chargertype == Coda)
     {
-      msg.buf[2] = highByte(uint16_t((settings.ChargeVsetpoint * settings.Scells ) * 10));
-      msg.buf[3] = lowByte(uint16_t((settings.ChargeVsetpoint * settings.Scells ) * 10));
+      // Data is big endian (MSB, LSB)
+      // Voltage scaling is value * 10
+      msg.id  = 0x050;
+      msg.len = 8;
+      msg.buf[0] = 0x00;
+      msg.buf[1] = 0xDC;
+      if ((settings.ChargeVsetpoint * settings.Scells ) > 200)
+      {
+        msg.buf[2] = highByte(uint16_t((settings.ChargeVsetpoint * settings.Scells ) * 10));
+        msg.buf[3] = lowByte(uint16_t((settings.ChargeVsetpoint * settings.Scells ) * 10));
+      }
+      else
+      {
+        // Voltage minimum is 200V -> 200 * 10 = 2000 -> 0x7D0
+        msg.buf[2] = 0x07;
+        msg.buf[3] = 0xD0;
+      }
+      msg.buf[4] = 0x00;
+      if ((settings.ChargeVsetpoint * settings.Scells)*chargecurrent < 3300)
+      {
+        msg.buf[5] = highByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
+        msg.buf[6] = lowByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
+      }
+      else //15 A AC limit
+      {
+        msg.buf[5] = 0x00;
+        msg.buf[6] = 0x96;
+      }
+      msg.buf[7] = 0x01; //HV charging
+      Can0.write(msg);
     }
-    else
-    {
-      // Voltage minimum is 200V -> 200 * 10 = 2000 -> 0x7D0
-      msg.buf[2] = 0x07;
-      msg.buf[3] = 0xD0;
-    }
-    msg.buf[4] = 0x00;
-    if ((settings.ChargeVsetpoint * settings.Scells)*chargecurrent < 3300)
-    {
-      msg.buf[5] = highByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
-      msg.buf[6] = lowByte(uint16_t(((settings.ChargeVsetpoint * settings.Scells) * chargecurrent) / 240));
-    }
-    else //15 A AC limit
-    {
-      msg.buf[5] = 0x00;
-      msg.buf[6] = 0x96;
-    }
-    msg.buf[7] = 0x01; //HV charging
-    Can0.write(msg);
-  }
-    
   }
 
   if (mescycl == 2)


### PR DESCRIPTION
The existing coded will work as long as the voltage is above 200. At 200 there is a scaling error. However there will be some precision issues with the current control.

Example - 15A should be 1500 lets say, which would be 0x05DC. What will go on the bus is 0x0505 as the lower byte is not being used.

This PR adds a few comments, fixes the issues above, and fixes the spacing to be in line.

It was unclear to be (but seems likely) that the `  if (mescycl == 2)` line is probably part of the Chevy Volt case. So right now that's being sent in all scenarios I think. But that is not addressed in this PR.

Thanks again for the great product, I hope this PR makes this fix even easier for you. :-)

-Matt