### PR TITLE
Balancing and cellVolt decode

### DIFF
--- a/VoltBMSV2/BMSModule.h
+++ b/VoltBMSV2/BMSModule.h
@@ -3,62 +3,62 @@
 
 class BMSModule
 {
-  public:
-    BMSModule();
-    void decodecan(int Id,CAN_message_t &msg);
-    void readStatus();
-    void clearmodule();
-     int getscells();
-    float getCellVoltage(int cell);
-    float getLowCellV();
-    float getHighCellV();
-    float getAverageV();
-    float getLowTemp();
-    float getHighTemp();
-    float getHighestModuleVolt();
-    float getLowestModuleVolt();
-    float getHighestCellVolt(int cell);
-    float getLowestCellVolt(int cell);
-    float getHighestTemp();
-    float getLowestTemp();
-    float getAvgTemp();
-    float getModuleVoltage();
-    float getTemperature(int temp);
-    uint8_t getFaults();
-    uint8_t getAlerts();
-    uint8_t getCOVCells();
-    uint8_t getCUVCells();
-    void setAddress(int newAddr);
-    int getAddress();
-    bool isExisting();
-            bool isReset();
-    void setReset(bool ex);
-    void setExists(bool ex);
-    void settempsensor(int tempsensor);
-    void setIgnoreCell(float Ignore);
-    int getCellsUsed ();
-    
-    
-  private:
-    float cellVolt[33];          // calculated as 16 bit value * 6.250 / 16383 = volts
-    float lowestCellVolt[33];
-    float highestCellVolt[33];
-    float moduleVolt;          // calculated as 16 bit value * 33.333 / 16383 = volts
-    float temperatures[5];     // Don't know the proper scaling at this point
-    float lowestTemperature;
-    float highestTemperature;
-    float lowestModuleVolt;
-    float highestModuleVolt;
-    float IgnoreCell;
-    bool exists;
-    bool reset;
-    int alerts;
-    int faults;
-    int COVFaults;
-    int CUVFaults;
-    int sensor;
-    uint8_t moduleAddress;     //1 to 0x3E
-    int scells;
-    int balstat;
-    int cellsused;
+public:
+  BMSModule();
+  void decodecan(int Id, CAN_message_t &msg);
+  void readStatus();
+  void clearmodule();
+  int getscells();
+  float getCellVoltage(int cell);
+  float getLowCellV();
+  float getHighCellV();
+  float getAverageV();
+  float getLowTemp();
+  float getHighTemp();
+  float getHighestModuleVolt();
+  float getLowestModuleVolt();
+  float getHighestCellVolt(int cell);
+  float getLowestCellVolt(int cell);
+  float getHighestTemp();
+  float getLowestTemp();
+  float getAvgTemp();
+  float getModuleVoltage();
+  float getTemperature(int temp);
+  uint8_t getFaults();
+  uint8_t getAlerts();
+  uint8_t getCOVCells();
+  uint8_t getCUVCells();
+  void setAddress(int newAddr);
+  int getAddress();
+  bool isExisting();
+  bool isReset();
+  void setReset(bool ex);
+  void setExists(bool ex);
+  void settempsensor(int tempsensor);
+  void setIgnoreCell(float Ignore);
+  int getCellsUsed();
+
+private:
+  float cellVolt[33]; // calculated as 16 bit value * 6.250 / 16383 = volts
+  float lowestCellVolt[33];
+  float highestCellVolt[33];
+  float moduleVolt;      // calculated as 16 bit value * 33.333 / 16383 = volts
+  float temperatures[5]; // Don't know the proper scaling at this point
+  float lowestTemperature;
+  float highestTemperature;
+  float lowestModuleVolt;
+  float highestModuleVolt;
+  float IgnoreCell;
+  bool exists;
+  bool reset;
+  int alerts;
+  int faults;
+  int COVFaults;
+  int CUVFaults;
+  int sensor;
+  uint8_t moduleAddress; //1 to 0x3E
+  int scells;
+  int balstat;
+  int cellsused;
+  float decodeCellVoltage(int cell, CAN_message_t &msg, int msb, int lsb);
 };

--- a/VoltBMSV2/BMSModuleManager.cpp
+++ b/VoltBMSV2/BMSModuleManager.cpp
@@ -136,6 +136,7 @@ void BMSModuleManager::balanceCells()
   msg.id = 0x300;
   msg.len = 8;
 
+  /*
   SERIALCONSOLE.print("   DEBUG Balance - ID:    ");
   SERIALCONSOLE.print(msg.id, HEX);
   SERIALCONSOLE.println("    ");
@@ -147,6 +148,7 @@ void BMSModuleManager::balanceCells()
     SERIALCONSOLE.print(msg.buf[i], BIN);
     SERIALCONSOLE.println(' ');
   }
+  */
 
   Can0.write(msg);
 
@@ -179,6 +181,7 @@ void BMSModuleManager::balanceCells()
   msg.id = 0x310;
   msg.len = 5;
 
+  /*
   SERIALCONSOLE.print("   DEBUG Balance - ID:    ");
   SERIALCONSOLE.print(msg.id, HEX);
   SERIALCONSOLE.println("    ");
@@ -190,6 +193,7 @@ void BMSModuleManager::balanceCells()
     SERIALCONSOLE.print(msg.buf[i], BIN);
     SERIALCONSOLE.println(' ');
   }
+  */
 
   Can0.write(msg);
 }

--- a/VoltBMSV2/BMSModuleManager.h
+++ b/VoltBMSV2/BMSModuleManager.h
@@ -5,61 +5,60 @@
 
 class BMSModuleManager
 {
-  public:
-    BMSModuleManager();
-    int seriescells();
-    void clearmodules();
-    void decodecan(CAN_message_t &msg);
-    void balanceCells();
-    void getAllVoltTemp();
-    void readSetpoints();
-    void setBatteryID(int id);
-    void setPstrings(int Pstrings);
-    void setUnderVolt(float newVal);
-    void setOverVolt(float newVal);
-    void setOverTemp(float newVal);
-    void setBalanceV(float newVal);
-    void setBalanceHyst(float newVal);
-    void setSensors(int sensor, float Ignore);
-    float getPackVoltage();
-    float getAvgTemperature();
-    float getHighTemperature();
-    float getLowTemperature();
-    float getAvgCellVolt();
-    float getLowCellVolt();
-    float getHighCellVolt();
-    float getHighVoltage();
-    float getLowVoltage();
-    /*
+public:
+  BMSModuleManager();
+  int seriescells();
+  void clearmodules();
+  void decodecan(CAN_message_t &msg);
+  void balanceCells();
+  void getAllVoltTemp();
+  void readSetpoints();
+  void setBatteryID(int id);
+  void setPstrings(int Pstrings);
+  void setUnderVolt(float newVal);
+  void setOverVolt(float newVal);
+  void setOverTemp(float newVal);
+  void setBalanceV(float newVal);
+  void setBalanceHyst(float newVal);
+  void setSensors(int sensor, float Ignore);
+  float getPackVoltage();
+  float getAvgTemperature();
+  float getHighTemperature();
+  float getLowTemperature();
+  float getAvgCellVolt();
+  float getLowCellVolt();
+  float getHighCellVolt();
+  float getHighVoltage();
+  float getLowVoltage();
+  /*
       void processCANMsg(CAN_FRAME &frame);
     */
-    void printAllCSV(unsigned long timestamp, float current, int SOC);
-    void printPackSummary();
-    void printPackDetails(int digits, bool port);
+  void printAllCSV(unsigned long timestamp, float current, int SOC);
+  void printPackSummary();
+  void printPackDetails(int digits, bool port);
 
-    bool checkcomms();
+  bool checkcomms();
 
-  private:
+private:
   CAN_message_t msg;
-    float packVolt;                         // All modules added together
-    int Pstring;
-    float LowCellVolt;
-    float HighCellVolt;
-    float lowestPackVolt;
-    float highestPackVolt;
-    float lowestPackTemp;
-    float highestPackTemp;
-    float highTemp;
-    float lowTemp;
-    BMSModule modules[MAX_MODULE_ADDR + 1]; // store data for as many modules as we've configured for.
-    int batteryID;
-    int numFoundModules;                    // The number of modules that seem to exist
-    bool isFaulted;
-    int spack;
-    /*
+  float packVolt; // All modules added together
+  int Pstring;
+  float LowCellVolt;
+  float HighCellVolt;
+  float lowestPackVolt;
+  float highestPackVolt;
+  float lowestPackTemp;
+  float highestPackTemp;
+  float highTemp;
+  float lowTemp;
+  BMSModule modules[MAX_MODULE_ADDR + 1]; // store data for as many modules as we've configured for.
+  int batteryID;
+  int numFoundModules; // The number of modules that seem to exist
+  bool isFaulted;
+  int spack;
+  /*
       void sendBatterySummary();
       void sendModuleSummary(int module);
       void sendCellDetails(int module, int cell);
     */
-
 };

--- a/VoltBMSV2/VoltBMSV2.ino
+++ b/VoltBMSV2/VoltBMSV2.ino
@@ -838,8 +838,10 @@ void loop()
     }
     else
     {
-
-      CanSerial();
+      if (settings.SerialCan == 1)
+        CanSerial();
+      else
+        chargercomms();
     }
 
   }

--- a/VoltBMSV2/VoltBMSV2.ino
+++ b/VoltBMSV2/VoltBMSV2.ino
@@ -3216,6 +3216,16 @@ void dashupdate()
   Serial2.write(0xff);  // We always have to send this three lines after each command sent to the nextion display.
   Serial2.write(0xff);
   Serial2.write(0xff);
+  Serial2.print("celldelta.val=");
+  Serial2.print(bms.getHighCellVolt() * 1000 - bms.getLowCellVolt() * 1000, 0);
+  Serial2.write(0xff);  // We always have to send this three lines after each command sent to the nextion display.
+  Serial2.write(0xff);
+  Serial2.write(0xff);
+  Serial2.print("cellbal.val=");
+  Serial2.print(balancecells);
+  Serial2.write(0xff);  // We always have to send this three lines after each command sent to the nextion display.
+  Serial2.write(0xff);
+  Serial2.write(0xff);
   Serial2.print("firm.val=");
   Serial2.print(firmver);
   Serial2.write(0xff);  // We always have to send this three lines after each command sent to the nextion display.


### PR DESCRIPTION
Reworked the balancing and cell decoding methods.
Cell decoding was missing a couple of bitmasks and reading high values (only while balancing). Risk of fully draining a couple of cells due to them being translated as 20+ Volts when they start balancing.

HEX not generated because can.exitSettingMode() is declared private in the Serial_CAN_Module_TeensyS3 library. Although the call to that method seems redundant and could be removed?